### PR TITLE
Add support for using existing resource group when creating NSG and RT

### DIFF
--- a/.config/.terraform-docs.yml
+++ b/.config/.terraform-docs.yml
@@ -14,9 +14,10 @@ content: |-
     {{ include "examples/example-1/main.tf" }}
     ```
     ### See more usage examples here:
-    - [:arrow_forward: Example Usage: Creating Subnet, NSG and RT](examples/example-2/main.tf)
-    - [:arrow_forward: Example Usage: Creating Subnet, NSG, RT, Adding UDR for NVA and Disabling BGP Propagation on route table](examples/example-3/main.tf)
-    - [:arrow_forward: Example Usage: Creating Subnet, NSG, RT and adding service endpoints to the subnet for Azure Storage and SQL](examples/example-4/main.tf)
+    - [:arrow_forward: Example: Creating a Subnet with Network Security Group and Route Table in Azure](examples/example-2/main.tf)
+    - [:arrow_forward: Example: Creating Subnet, NSG, Route Table, and Adding UDR for NVA](examples/example-3/main.tf)
+    - [:arrow_forward: Example: Creating a Subnet with Network Security Group, Route Table, and Service Endpoints](examples/example-4/main.tf)
+    - [:arrow_forward: Example: Creating Subnet, NSG, and Route Table in an Existing Resource Group](examples/example-5/main.tf)
 
     > :information_source: **Note:** <br>
     > Otherwise, see the full module test here: [:arrow_forward: test/autotest](test/autotest/main.tf) <br>

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ override.tf.json
 # !example_override.tf
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+# example: 
+*.plan
+*.tfplan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
-Unreleased
-==========
+# CHANGELOG
 
-x.x.0
-===
->Add a description and/or bullet points of what changes has been done in the new version.
+All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2024-03-05
+### Added
+- Support for creating NSG and Route Table in an existing resource group. See [#2](https://github.com/haflidif/terraform-azurerm-alz-subnet/issues/2).
+- Added more detailed examples and README file for each example.
+
+### Fixed
+- Closes [#2](https://github.com/haflidif/terraform-azurerm-alz-subnet/issues/2).
+
+## [1.0.3] - 2024-02-25
+### Changed
+- build(deps): Bump zwaldowski/semver-release-action from 3 to 4 by @dependabot in [PR #3](https://github.com/haflidif/terraform-azurerm-alz-subnet/pull/4)
+
+## [1.0.2] - 2024-02-11
+### Changed
+- build(deps): Bump ncipollo/release-action from 1.13.0 to 1.14.0 by @dependabot in [PR #2](https://github.com/haflidif/terraform-azurerm-alz-subnet/pull/3)
+
+
+## [1.0.1] - 2023-10-22
+### Changed
+- build(deps): Bump actions/checkout from 4.1.0 to 4.1.1 by @dependabot in [PR #1](https://github.com/haflidif/terraform-azurerm-alz-subnet/pull/1)
+
+## [1.0.0] - 2023-10-05
+- Initial Release https://github.com/haflidif/terraform-azurerm-alz-subnet/commits/1.0.0

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ module "subnet" {
 | <a name="input_create_route_table"></a> [create\_route\_table](#input\_create\_route\_table) | (Optional) Boolean flag which controls if route table should be created. Defaults to `true`. Set to `false` and provide value for `route_table_id` to reference existing route table. | `bool` | `true` | no |
 | <a name="input_delegation_service_name"></a> [delegation\_service\_name](#input\_delegation\_service\_name) | (Optional) Provide the service name for the subnet delegation configuration. | `string` | `""` | no |
 | <a name="input_disable_bgp_route_propagation"></a> [disable\_bgp\_route\_propagation](#input\_disable\_bgp\_route\_propagation) | (Optional) Boolean flag which controls propagation of routes learned by BGP on that route table. `true` means disable. Defaults to `false`, when used in combination with `create_sub_network_resources` and 'nva\_ip\_address' this should be set to `true` to prevent the default 0.0.0.0/0 route to be propagated in the route table via BGP. | `bool` | `false` | no |
+| <a name="input_existing_resource_group_name"></a> [existing\_resource\_group\_name](#input\_existing\_resource\_group\_name) | (Optional) The name of an existing resource group where the nsg and route table will be created. Changing this forces a new resource to be created. | `string` | `""` | no |
 | <a name="input_network_security_group_id"></a> [network\_security\_group\_id](#input\_network\_security\_group\_id) | (Optional) The ID of existing network security group to associate with the subnet. | `string` | `""` | no |
 | <a name="input_network_security_group_name"></a> [network\_security\_group\_name](#input\_network\_security\_group\_name) | (Optional) The name of the new network security group to associate with the subnet. | `string` | `""` | no |
 | <a name="input_nva_ip_address"></a> [nva\_ip\_address](#input\_nva\_ip\_address) | (Optional) The IP address of the network virtual appliance often a firewall, located in a hub virtual network, this is used to create user defined route to route 0.0.0.0/0 traffic to the network virtual appliance. | `string` | `""` | no |
@@ -126,6 +127,7 @@ module "subnet" {
 | <a name="input_service_endpoint_names"></a> [service\_endpoint\_names](#input\_service\_endpoint\_names) | (Optional) List of service endpoints to associate with the subnet. | `list(string)` | `[]` | no |
 | <a name="input_sub_resource_group_name"></a> [sub\_resource\_group\_name](#input\_sub\_resource\_group\_name) | (Optional) The name of the resource group where the sub-resources will be created. Changing this forces a new resource to be created. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource. | `map(string)` | `{}` | no |
+| <a name="input_use_existing_resource_group"></a> [use\_existing\_resource\_group](#input\_use\_existing\_resource\_group) | (Optional) Boolean flag which controls if an existing resource group should be used. Defaults to `false`. | `bool` | `false` | no |
 ## Outputs
 
 | Name | Description |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ The following arguments are supported:
 
 - `location` - (Required) Specifies the Azure location where the resources should be created. Changing this forces a new resource to be created.
 
+- `use_existing_resource_group` - (Optional) Boolean flag which controls if an existing resource group should be used for the NSG and Route Table. Defaults to `false`.
+
+- `existing_resource_group_name` - (Optional) The name of an existing resource group where the NSG and Route Table will be created. Changing this forces a new resource to be created.
+
 - `create_network_security_group` - (Optional) Boolean flag which controls if network security group should be created. Defaults to `true`. Set to `false` and provide value for **`network_security_group_id`** to reference existing network security group.
   > :information_source: **NOTE:**
   > <br>

--- a/examples/example-1/README.md
+++ b/examples/example-1/README.md
@@ -1,0 +1,49 @@
+# Example: Using Pre-created Network Security Group and Route Table
+
+This example demonstrates how to use the `haflidif/alz-subnet/azurerm` Terraform module to create a subnet in Azure and associate it with a pre-created Network Security Group (NSG) and Route Table.
+
+## Pre-requisites Setup
+
+First, we need to set up the necessary resources that our subnet will be associated with. This includes creating a resource group, a virtual network, a route table, and a network security group.
+
+```hcl
+resource "azurerm_resource_group" "this" {
+  name     = "rg-test-01"
+  location = "westeurope"
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet-alz-01"
+  address_space       = ["10.30.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "azurerm_route_table" "this" {
+  name                = "rt-alz-01"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+resource "azurerm_network_security_group" "this" {
+  name                = "nsg-alz-01"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+```
+## Creating Subnet and Associating with NSG and Route Table
+Now, we can use the `haflidif/alz-subnet/azurerm` module to create a subnet and associate it with the pre-created NSG and Route Table. We pass in the necessary parameters, including the ID of the virtual network, route table, and network security group we created earlier.
+```hcl
+module "subnet" {
+  source                        = "haflidif/alz-subnet/azurerm"
+  subnet_name                   = "snet-alz-01"
+  address_prefixes              = ["10.30.0.0/27"]
+  virtual_network_resource_id   = azurerm_virtual_network.this.id
+  location                      = azurerm_resource_group.this.location
+  create_network_security_group = false
+  create_route_table            = false
+  route_table_id                = azurerm_route_table.this.id
+  network_security_group_id     = azurerm_network_security_group.this.id
+}
+```
+This will create a subnet named `snet-alz-01` within the `vnet-alz-01` virtual network and associate it with the `nsg-alz-01` NSG and `rt-alz-01` Route Table.

--- a/examples/example-2/README.md
+++ b/examples/example-2/README.md
@@ -1,0 +1,41 @@
+# Example: Creating a Subnet with Network Security Group and Route Table in Azure
+
+This example demonstrates how to create a subnet in Azure with a Network Security Group (NSG) and a Route Table using the `haflidif/alz-subnet/azurerm` Terraform module.
+
+## Pre-requisites Setup
+
+First, we need to set up the necessary resources that our subnet will be associated with. This includes creating a resource group and a virtual network.
+
+```hcl
+resource "azurerm_resource_group" "this" {
+  name     = "rg-test-01"
+  location = "westeurope"
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet-alz-01"
+  address_space       = ["10.30.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+```
+
+## Creating Subnet, NSG, and Route Table
+Now, we can use the `haflidif/alz-subnet/azurerm` module to create a subnet, NSG, and Route Table. We pass in the necessary parameters, including the ID of the virtual network we created earlier, and flags to indicate that we want to create an NSG and Route Table.
+
+```hcl
+module "subnet" {
+  source                        = "haflidif/alz-subnet/azurerm"
+  subnet_name                   = "snet-alz-01"
+  address_prefixes              = ["10.30.0.0/27"]
+  virtual_network_resource_id   = azurerm_virtual_network.this.id
+  location                      = azurerm_resource_group.this.location
+  create_network_security_group = true
+  create_route_table            = true
+  sub_resource_group_name       = "rg-snet-alz-01-sub-resources"
+  route_table_name              = "rt-alz-01"
+  network_security_group_name   = "nsg-alz-01"
+}
+```
+
+This will create a subnet named `snet-alz-01` within the `vnet-alz-01` virtual network. It will also create an NSG named `nsg-alz-01` and a Route Table named `rt-alz-01` within the `rg-snet-alz-01-sub-resources` resource group.

--- a/examples/example-3/README.md
+++ b/examples/example-3/README.md
@@ -1,0 +1,40 @@
+# Example: Creating Subnet, NSG, Route Table, and Adding UDR for NVA
+
+This example demonstrates how to use the `haflidif/alz-subnet/azurerm` Terraform module to create a subnet in Azure, associate it with a Network Security Group (NSG) and Route Table, add a User Defined Route (UDR) for a Network Virtual Appliance (NVA), and disable BGP route propagation on the route table.
+
+## Pre-requisites Setup
+
+First, we need to set up the necessary resources that our subnet will be associated with. This includes creating a resource group and a virtual network.
+
+```hcl
+resource "azurerm_resource_group" "this" {
+  name     = "rg-test-01"
+  location = "westeurope"
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet-alz-01"
+  address_space       = ["10.30.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+```
+## Creating Subnet, NSG, Route Table, Adding UDR for NVA, and Disabling BGP Propagation
+Now, we can use the `haflidif/alz-subnet/azurerm` module to create a subnet, NSG, and Route Table, add a UDR for an NVA, and disable BGP route propagation. We pass in the necessary parameters, including the ID of the virtual network we created earlier, the IP address of the NVA, and flags to indicate that we want to create an NSG and Route Table and disable BGP route propagation.
+```hcl
+module "subnet" {
+  source                        = "haflidif/alz-subnet/azurerm"
+  subnet_name                   = "snet-alz-01"
+  address_prefixes              = ["10.30.0.0/27"]
+  virtual_network_resource_id   = azurerm_virtual_network.this.id
+  location                      = azurerm_resource_group.this.location
+  create_network_security_group = true
+  create_route_table            = true
+  sub_resource_group_name       = "rg-snet-alz-01-sub-resources"
+  route_table_name              = "rt-alz-01"
+  network_security_group_name   = "nsg-alz-01"
+  disable_bgp_route_propagation = true
+  nva_ip_address                = "10.20.0.4"
+}
+```
+This will create a subnet named `snet-alz-01` within the `vnet-alz-01` virtual network. It will also create an NSG named `nsg-alz-01` and a Route Table named `rt-alz-01` within the `rg-snet-alz-01-sub-resources` resource group. The route table will have a UDR added for an NVA with the IP address `10.20.0.4`, and BGP route propagation will be disabled.

--- a/examples/example-4/README.md
+++ b/examples/example-4/README.md
@@ -1,0 +1,42 @@
+# Example: Creating a Subnet with Network Security Group, Route Table, and Service Endpoints
+
+This example demonstrates how to use the `haflidif/alz-subnet/azurerm` Terraform module to create a subnet in Azure, associate it with a Network Security Group (NSG) and Route Table, and enable service endpoints for Azure Storage and SQL.
+
+## Pre-requisites Setup
+
+First, we need to set up the necessary resources that our subnet will be associated with. This includes creating a resource group and a virtual network.
+
+```hcl
+resource "azurerm_resource_group" "this" {
+  name     = "rg-test-01"
+  location = "westeurope"
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet-alz-01"
+  address_space       = ["10.30.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+```
+## Creating Subnet, NSG, Route Table, and Enabling Service Endpoints
+Now, we can use the `haflidif/alz-subnet/azurerm` module to create a subnet, NSG, and Route Table. We pass in the necessary parameters, including the ID of the virtual network we created earlier, and flags to indicate that we want to create an NSG and Route Table. We also specify the service endpoints we want to enable.
+    
+```hcl
+module "subnet" {
+  source                        = "haflidif/alz-subnet/azurerm"
+  subnet_name                   = "snet-alz-01"
+  address_prefixes              = ["10.30.0.0/27"]
+  virtual_network_resource_id   = azurerm_virtual_network.this.id
+  location                      = azurerm_resource_group.this.location
+  create_network_security_group = true
+  create_route_table            = true
+  sub_resource_group_name       = "rg-snet-alz-01-sub-resources"
+  route_table_name              = "rt-alz-01"
+  network_security_group_name   = "nsg-alz-01"
+  service_endpoint_names        = ["Microsoft.Storage", "Microsoft.Sql"]
+}
+```
+This will create a subnet named `snet-alz-01` within the `vnet-alz-01` virtual network. It will also create an NSG named `nsg-alz-01` and a Route Table named `rt-alz-01` within the `rg-snet-alz-01-sub-resources` resource group. The subnet will have service endpoints enabled for `Azure Storage` and `SQL`.
+
+    

--- a/examples/example-5/README.md
+++ b/examples/example-5/README.md
@@ -1,0 +1,45 @@
+# Example: Creating Subnet, NSG, and Route Table in an Existing Resource Group
+
+This example demonstrates how to use the `haflidif/alz-subnet/azurerm` Terraform module to create a subnet in Azure, associate it with a Network Security Group (NSG) and Route Table, and place these resources in an existing resource group.
+
+## Pre-requisites Setup
+
+First, we need to set up the necessary resources that our subnet will be associated with. This includes creating two resource groups and a virtual network.
+
+```hcl
+resource "azurerm_resource_group" "this" {
+  name     = "rg-test-01"
+  location = "westeurope"
+}
+
+resource "azurerm_resource_group" "existing" {
+  name     = "rg-test-existing-01"
+  location = "westeurope"  
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet-alz-01"
+  address_space       = ["10.30.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+```
+
+## Creating Subnet, NSG, and Route Table in Existing Resource Group
+Now, we can use the `haflidif/alz-subnet/azurerm` module to create a subnet, NSG, and Route Table in the existing resource group. We pass in the necessary parameters, including the ID of the virtual network we created earlier, the name of the existing resource group, and flags to indicate that we want to create an NSG and Route Table.
+```hcl
+module "subnet" {
+  source                        = "haflidif/alz-subnet/azurerm"
+  subnet_name                   = "snet-alz-01"
+  address_prefixes              = ["10.30.0.0/27"]
+  virtual_network_resource_id   = azurerm_virtual_network.this.id
+  location                      = azurerm_resource_group.this.location
+  create_network_security_group = true
+  create_route_table            = true
+  use_existing_resource_group   = true
+  existing_resource_group_name  = azurerm_resource_group.existing.name
+  route_table_name              = "rt-alz-01"
+  network_security_group_name   = "nsg-alz-01"
+}
+```
+This will create a subnet named `snet-alz-01` within the `vnet-alz-01` virtual network. It will also create an NSG named `nsg-alz-01` and a Route Table named `rt-alz-01` within the `rg-test-existing-01` resource group.

--- a/examples/example-5/main.tf
+++ b/examples/example-5/main.tf
@@ -1,0 +1,40 @@
+# Simple usage to showcase several functionalities of the module
+
+########################
+# Pre-requisites Setup #
+########################
+
+resource "azurerm_resource_group" "this" {
+  name     = "rg-test-01"
+  location = "westeurope"
+}
+
+resource "azurerm_resource_group" "existing" {
+  name     = "rg-test-existing-01"
+  location = "westeurope"
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = "vnet-alz-01"
+  address_space       = ["10.30.0.0/24"]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+###################################################################################################################
+#    Example Usage: Creating Subnet in addition to NSG and RT within a existing resource group                    #
+###################################################################################################################
+
+module "subnet" {
+  source                        = "haflidif/alz-subnet/azurerm"
+  subnet_name                   = "snet-alz-01"
+  address_prefixes              = ["10.30.0.0/27"]
+  virtual_network_resource_id   = azurerm_virtual_network.this.id
+  location                      = azurerm_resource_group.this.location
+  create_network_security_group = true
+  create_route_table            = true
+  use_existing_resource_group   = true
+  existing_resource_group_name  = azurerm_resource_group.existing.name
+  route_table_name              = "rt-alz-01"
+  network_security_group_name   = "nsg-alz-01"
+}

--- a/examples/example-5/provider.tf
+++ b/examples/example-5/provider.tf
@@ -1,0 +1,4 @@
+provider "azurerm" {
+  subscription_id = "<Subscription ID>"
+  features {}
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,9 @@
 # Add all local concatenation and values here
 locals {
 
+  # Creating a local value to support using existing resource group or creating a new one.
+  resource_group_name = var.existing_resource_group_name != "" ? var.existing_resource_group_name : var.sub_resource_group_name
+
   # Creating local value to handle empty tuple of azurerm_route_table when var.route_table_id is supplied.
   created_route_table_id = var.create_route_table == true && var.route_table_name != "" ? try(azurerm_route_table.route_table[0].id) : ""
 
@@ -30,4 +33,5 @@ locals {
       service = serviceEndpoint
     }
   ]
+
 }

--- a/test/autotest/testing.tfvars
+++ b/test/autotest/testing.tfvars
@@ -13,6 +13,7 @@ alz_new_nsg_rt_service_endpoint_address_space = ["10.30.0.64/27"]
 alz_new_nsg_rt_delegate_address_space         = ["10.30.0.96/27"]
 alz_new_nsg_rt_nva_ip_udr_address_space       = ["10.30.0.128/27"]
 alz_new_nsg_existing_rt_address_space         = ["10.30.0.160/27"]
+alz_existing_rg_address_space                 = ["10.30.0.192/27"]
 nva_ip_address                                = "10.20.0.4"
 
 tags = {

--- a/test/autotest/variables.tf
+++ b/test/autotest/variables.tf
@@ -78,6 +78,12 @@ variable "alz_new_nsg_existing_rt_address_space" {
   description = "Address prefix for the subnet test with new NSG and existing RT"
 }
 
+variable "alz_existing_rg_address_space" {
+  type        = list(string)
+  default     = ["10.30.0.192/27"]
+  description = "Address prefix for the subnet test with existing RG"
+}
+
 variable "nva_ip_address" {
   description = "(Optional) The IP address of the network virtual appliance often a firewall, located in a hub virtual network, this is used to create user defined route to route"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,18 @@ variable "location" {
 ###       Optional Variables       ###
 ######################################
 
+variable "use_existing_resource_group" {
+  description = "(Optional) Boolean flag which controls if an existing resource group should be used. Defaults to `false`."
+  type        = bool
+  default     = false
+}
+
+variable "existing_resource_group_name" {
+  description = "(Optional) The name of an existing resource group where the nsg and route table will be created. Changing this forces a new resource to be created."
+  type        = string
+  default     = ""
+}
+
 variable "sub_resource_group_name" {
   description = "(Optional) The name of the resource group where the sub-resources will be created. Changing this forces a new resource to be created."
   type        = string


### PR DESCRIPTION
# Description

This pull request introduces an enhancement allowing the use of an existing resource group for the creation of network security group (NSG) and route table (RT) associated with each subnet. 

The update includes:
- Code modifications to implement the new feature
- Updated examples demonstrating the usage of an existing resource group
- Documentation updates reflecting the new changes

This update ensures backward compatibility and introduces no breaking changes.

This enhancement addresses and resolves issue #2.