### PR TITLE
Support creating Subnet without creating or reference existing Route Table

### DIFF
--- a/.config/.terraform-docs.yml
+++ b/.config/.terraform-docs.yml
@@ -1,8 +1,6 @@
 # .terraform-docs.yml
 
 formatter: "markdown table"
-settings:
-  color: true
 content: |-
   {{ .Header }}
   

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Please have a look at the [Known Issues](#known-issues) section for more informa
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.9, < 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.11, < 4.0 |
 
-## Simple module usage
-
-```hcl
-# Simple usage to showcase the functionality of the module
+  ## Simple module usage
+      
+  ```hcl
+  # Simple usage to showcase the functionality of the module
 
 ########################
 # Pre-requisites Setup #
@@ -86,14 +86,15 @@ module "subnet" {
   route_table_id                = azurerm_route_table.this.id
   network_security_group_id     = azurerm_network_security_group.this.id
 }
-```
-### See more usage examples here:
-- [:arrow_forward: Example Usage: Creating Subnet, NSG and RT](examples/example-2/main.tf)
-- [:arrow_forward: Example Usage: Creating Subnet, NSG, RT, Adding UDR for NVA and Disabling BGP Propagation on route table](examples/example-3/main.tf)
-- [:arrow_forward: Example Usage: Creating Subnet, NSG, RT and adding service endpoints to the subnet for Azure Storage and SQL](examples/example-4/main.tf)
+  ```
+  ### See more usage examples here:
+  - [:arrow_forward: Example: Creating a Subnet with Network Security Group and Route Table in Azure](examples/example-2/main.tf)
+  - [:arrow_forward: Example: Creating Subnet, NSG, Route Table, and Adding UDR for NVA](examples/example-3/main.tf)
+  - [:arrow_forward: Example: Creating a Subnet with Network Security Group, Route Table, and Service Endpoints](examples/example-4/main.tf)
+  - [:arrow_forward: Example: Creating Subnet, NSG, and Route Table in an Existing Resource Group](examples/example-5/main.tf)
 
-> :information_source: **Note:** <br>
-> Otherwise, see the full module test here: [:arrow_forward: test/autotest](test/autotest/main.tf) <br>
+  > :information_source: **Note:** <br>
+  > Otherwise, see the full module test here: [:arrow_forward: test/autotest](test/autotest/main.tf) <br>
 
 ## Resources
 
@@ -113,7 +114,7 @@ module "subnet" {
 | <a name="input_subnet_name"></a> [subnet\_name](#input\_subnet\_name) | (Required) Name of the subnet. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_virtual_network_resource_id"></a> [virtual\_network\_resource\_id](#input\_virtual\_network\_resource\_id) | (Required) The ID of the virtual network where the subnet should be created. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_create_network_security_group"></a> [create\_network\_security\_group](#input\_create\_network\_security\_group) | (Optional) Boolean flag which controls if network security group should be created. Defaults to `true`. Set to `false` and provide value for `network_security_group_id` to reference existing network security group. | `bool` | `true` | no |
-| <a name="input_create_route_table"></a> [create\_route\_table](#input\_create\_route\_table) | (Optional) Boolean flag which controls if route table should be created. Defaults to `true`. Set to `false` and provide value for `route_table_id` to reference existing route table. | `bool` | `true` | no |
+| <a name="input_create_route_table"></a> [create\_route\_table](#input\_create\_route\_table) | (Optional) Boolean flag which controls if route table should be created. Defaults to `true`. Set to `false` and either provide value for `route_table_id` to reference existing route table, or skip providing value for `route_table_id` to not use a route table at all. | `bool` | `true` | no |
 | <a name="input_delegation_service_name"></a> [delegation\_service\_name](#input\_delegation\_service\_name) | (Optional) Provide the service name for the subnet delegation configuration. | `string` | `""` | no |
 | <a name="input_disable_bgp_route_propagation"></a> [disable\_bgp\_route\_propagation](#input\_disable\_bgp\_route\_propagation) | (Optional) Boolean flag which controls propagation of routes learned by BGP on that route table. `true` means disable. Defaults to `false`, when used in combination with `create_sub_network_resources` and 'nva\_ip\_address' this should be set to `true` to prevent the default 0.0.0.0/0 route to be propagated in the route table via BGP. | `bool` | `false` | no |
 | <a name="input_existing_resource_group_name"></a> [existing\_resource\_group\_name](#input\_existing\_resource\_group\_name) | (Optional) The name of an existing resource group where the nsg and route table will be created. Changing this forces a new resource to be created. | `string` | `""` | no |
@@ -138,7 +139,6 @@ module "subnet" {
 ## Modules
 
 No modules.
-
 <!-- END_TF_DOCS -->
 
 ## Argument Reference

--- a/main.tf
+++ b/main.tf
@@ -83,13 +83,16 @@ resource "azapi_resource" "subnet" {
       privateEndpointNetworkPolicies    = lookup(local.private_link_and_endpoint_network_policies_enabled_map, var.private_endpoint_network_policies_enabled)
       privateLinkServiceNetworkPolicies = lookup(local.private_link_and_endpoint_network_policies_enabled_map, var.private_link_service_network_policies_enabled)
 
-      networkSecurityGroup = {
-        id = coalesce(var.network_security_group_id, local.created_network_security_group_id)
-      }
+      # Conditionally include networkSecurityGroup
+      networkSecurityGroup = var.network_security_group_id != "" || local.created_network_security_group_id != "" ? {
+        id = try(coalesce(var.network_security_group_id, local.created_network_security_group_id), "")
+      } : null
 
-      routeTable = {
-        id = coalesce(var.route_table_id, local.created_route_table_id)
-      }
+      # Conditionally include routeTable
+      routeTable = var.route_table_id != "" || local.created_route_table_id != "" ? {
+        id = try(coalesce(var.route_table_id, local.created_route_table_id), "")
+      } : null
+
     }
   })
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,12 +7,12 @@ output "subnet_id" {
 
 # Outputs the Network Security Group Id if created by this module, otherwise it will output the id of the network security group referenced by the input variable.
 output "subnet_nsg_id" {
-  value       = coalesce(var.network_security_group_id, local.created_network_security_group_id)
+  value       = try(coalesce(var.network_security_group_id, local.created_network_security_group_id), null)
   description = "Network Security Group resource id"
 }
 
 # Outputs the Route Table Id if created by this module, otherwise it will output the id of the route table referenced by the input variable.
 output "subnet_route_table_id" {
-  value       = coalesce(var.route_table_id, local.created_route_table_id)
+  value       = try(coalesce(var.route_table_id, local.created_route_table_id), null)
   description = "Route Table resource id"
 }

--- a/test/autotest/main.tf
+++ b/test/autotest/main.tf
@@ -9,7 +9,7 @@ resource "random_id" "rg" {
 
 # Creating multiple Random id to append to the resources created by the module.
 resource "random_id" "test" {
-  count       = 6
+  count       = 7
   byte_length = 4
 }
 
@@ -174,11 +174,32 @@ module "subnet_existing_rg" {
   existing_resource_group_name  = azurerm_resource_group.existing.name
   create_network_security_group = true
   create_route_table            = true
-  route_table_name            = "${var.prereq_route_table_name}-${lower(random_id.test[5].hex)}"
-  network_security_group_name = "${var.prereq_network_security_group_name}-${lower(random_id.test[5].hex)}"
+  route_table_name              = "${var.prereq_route_table_name}-${lower(random_id.test[5].hex)}"
+  network_security_group_name   = "${var.prereq_network_security_group_name}-${lower(random_id.test[5].hex)}"
   tags                          = var.tags
 
   depends_on = [module.subnet_new_nsg_existing_rt]
+}
+
+################################################################################
+#         Testing: Subnet with existing resource group for NSG but without RT  #
+################################################################################
+
+module "subnet_existing_rg_no_rt" {
+  source                        = "../.."
+  subnet_name                   = "alz-subnet-module-test-snet-existing-rg-no-rt"
+  address_prefixes              = var.alz_existing_rg_no_rt_address_space
+  virtual_network_resource_id   = azurerm_virtual_network.this.id
+  location                      = azurerm_resource_group.this.location
+  use_existing_resource_group   = true
+  existing_resource_group_name  = azurerm_resource_group.existing.name
+  create_network_security_group = true
+  create_route_table            = false
+  network_security_group_name   = "${var.prereq_network_security_group_name}-${lower(random_id.test[6].hex)}"
+  tags                          = var.tags
+
+  depends_on = [module.subnet_existing_rg]
+
 }
 
 output "subnets" {
@@ -190,6 +211,7 @@ output "subnets" {
     subnet_nsg_rt_udr          = module.subnet_nsg_rt_udr.subnet_id
     subnet_new_nsg_existing_rt = module.subnet_new_nsg_existing_rt.subnet_id
     subnet_existing_rg         = module.subnet_existing_rg.subnet_id
+    subnet_existing_rg_no_rt   = module.subnet_existing_rg_no_rt.subnet_id
   }
 }
 
@@ -202,6 +224,7 @@ output "route_table_ids" {
     subnet_nsg_rt_udr          = module.subnet_nsg_rt_udr.subnet_route_table_id
     subnet_new_nsg_existing_rt = module.subnet_new_nsg_existing_rt.subnet_route_table_id
     subnet_existing_rg         = module.subnet_existing_rg.subnet_route_table_id
+    subnet_existing_rg_no_rt   = module.subnet_existing_rg_no_rt.subnet_route_table_id
   }
 }
 
@@ -214,5 +237,6 @@ output "network_security_group_ids" {
     subnet_nsg_rt_udr          = module.subnet_nsg_rt_udr.subnet_nsg_id
     subnet_new_nsg_existing_rt = module.subnet_new_nsg_existing_rt.subnet_nsg_id
     subnet_existing_rg         = module.subnet_existing_rg.subnet_nsg_id
+    subnet_existing_rg_no_rt   = module.subnet_existing_rg_no_rt.subnet_nsg_id
   }
 }

--- a/test/autotest/testing.tfvars
+++ b/test/autotest/testing.tfvars
@@ -14,6 +14,7 @@ alz_new_nsg_rt_delegate_address_space         = ["10.30.0.96/27"]
 alz_new_nsg_rt_nva_ip_udr_address_space       = ["10.30.0.128/27"]
 alz_new_nsg_existing_rt_address_space         = ["10.30.0.160/27"]
 alz_existing_rg_address_space                 = ["10.30.0.192/27"]
+alz_existing_rg_no_rt_address_space           = ["10.30.0.224/28"]
 nva_ip_address                                = "10.20.0.4"
 
 tags = {

--- a/test/autotest/variables.tf
+++ b/test/autotest/variables.tf
@@ -84,6 +84,12 @@ variable "alz_existing_rg_address_space" {
   description = "Address prefix for the subnet test with existing RG"
 }
 
+variable "alz_existing_rg_no_rt_address_space" {
+  type        = list(string)
+  default     = ["10.30.0.224/28"]
+  description = "Address prefix for the subnet test with existing RG and no RT"
+}
+
 variable "nva_ip_address" {
   description = "(Optional) The IP address of the network virtual appliance often a firewall, located in a hub virtual network, this is used to create user defined route to route"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "network_security_group_name" {
 }
 
 variable "create_route_table" {
-  description = "(Optional) Boolean flag which controls if route table should be created. Defaults to `true`. Set to `false` and provide value for `route_table_id` to reference existing route table."
+  description = "(Optional) Boolean flag which controls if route table should be created. Defaults to `true`. Set to `false` and either provide value for `route_table_id` to reference existing route table, or skip providing value for `route_table_id` to not use a route table at all."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
This small non-breaking changes update introduces the possibility to create subnet without creating a route table or referencing an existing one, the reason is simple, few services in Azure do not support route tables as well as when using vWan hub and routing-intent you don't need a separate route table for the subnet unless you want to create custom UDRs.

resolves #13 