### PR TITLE
Update Dependency and PR Tests to Use New GitHub Action with Managed Identity and Federated Credentials

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -38,7 +38,6 @@ jobs:
           az_resource_group: rg-azviking-tfstate ## (Required) AZ backend - AZURE Resource Group hosting terraform backend storage account
           az_storage_account_name: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
           az_storage_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
-          az_storage_key: alz-subnet-testing ## (Required) AZ backend - AZURE storage account key
           arm_client_id: ${{ secrets.ARM_CLIENT_ID }} ## (Required - Dependabot Secrets) ARM Client ID
           arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }} ## (Required - Dependabot Secrets) ARM Subscription ID
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }} ## (Required - Dependabot Secrets) ARM Tenant ID

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,11 +33,12 @@ jobs:
           test_type: plan ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.
           tf_version: latest ## (Optional) Specifies version of Terraform to use. e.g: 1.1.0 Default="latest"
-          tf_vars_file: testing.tfvars ## (Required) Specifies Terraform TFVARS file name inside module path (Testing vars)
-          tf_key: tf-mod-test-alz-subnet ## (Required) AZ backend - Specifies name that will be given to terraform state file and plan artifact (testing state)
+          tf_var_file: testing.tfvars ## (Required) Specifies Terraform TFVARS file name inside module path (Testing vars)
+          tf_state_file: tf-mod-test-alz-subnet ## (Required) AZ backend - Specifies name that will be given to terraform state file and plan artifact (testing state)
           az_resource_group: rg-azviking-tfstate ## (Required) AZ backend - AZURE Resource Group hosting terraform backend storage account
-          az_storage_acc: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
-          az_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
+          az_storage_account_name: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
+          az_storage_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
+          az_storage_key: alz-subnet-testing ## (Required) AZ backend - AZURE storage account key
           arm_client_id: ${{ secrets.ARM_CLIENT_ID }} ## (Required - Dependabot Secrets) ARM Client ID
           arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }} ## (Required - Dependabot Secrets) ARM Subscription ID
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }} ## (Required - Dependabot Secrets) ARM Tenant ID

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,6 +41,7 @@ jobs:
           az_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
           arm_client_id: ${{ secrets.ARM_CLIENT_ID }} ## (Required - Dependabot Secrets) ARM Client ID
           arm_use_oidc: true ## (Optional) Use OIDC to authenticate to Azure
+          arm_use_azuread: true ## (Optional) Use Azure AD to authenticate to Azure Storage Account
           # arm_client_secret: ${{ secrets.ARM_CLIENT_SECRET }} ## (Required - Dependabot Secrets) ARM Client Secret
           arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }} ## (Required - Dependabot Secrets) ARM Subscription ID
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }} ## (Required - Dependabot Secrets) ARM Tenant ID

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,8 +28,7 @@ jobs:
         uses: actions/checkout@v4.2.0
 
       - name: Run Automated Tests - Terraform Plan
-        # uses: Pwd9000-ML/terraform-azurerm-tests@v1.1.0
-        uses: haflidif/terraform-azurerm-tests@support-for-oidc-entra-id-auth
+        uses: haflidif/terraform-tests-azure@main
         with:
           test_type: plan ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.
@@ -40,9 +39,6 @@ jobs:
           az_storage_acc: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
           az_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
           arm_client_id: ${{ secrets.ARM_CLIENT_ID }} ## (Required - Dependabot Secrets) ARM Client ID
-          arm_use_oidc: true ## (Optional) Use OIDC to authenticate to Azure
-          arm_use_azuread: true ## (Optional) Use Azure AD to authenticate to Azure Storage Account
-          # arm_client_secret: ${{ secrets.ARM_CLIENT_SECRET }} ## (Required - Dependabot Secrets) ARM Client Secret
           arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }} ## (Required - Dependabot Secrets) ARM Subscription ID
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }} ## (Required - Dependabot Secrets) ARM Tenant ID
           github_token: ${{ secrets.GITHUB_TOKEN }} ## (Required) Needed to comment output on PR's. ${{ secrets.GITHUB_TOKEN }} already has permissions.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4.2.0
 
       - name: Run Automated Tests - Terraform Plan
-        uses: haflidif/terraform-tests-azure@main
+        uses: haflidif/terraform-azure-tests@main
         with:
           test_type: plan ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/checkout@v4.2.0
 
       - name: Run Automated Tests - Terraform Plan
-        uses: Pwd9000-ML/terraform-azurerm-tests@v1.1.0
+        # uses: Pwd9000-ML/terraform-azurerm-tests@v1.1.0
+        uses: haflidif/terraform-azurerm-tests@support-for-oidc-entra-id-auth
         with:
           test_type: plan ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.
@@ -39,6 +40,7 @@ jobs:
           az_storage_acc: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
           az_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
           arm_client_id: ${{ secrets.ARM_CLIENT_ID }} ## (Required - Dependabot Secrets) ARM Client ID
+          arm_use_oidc: true ## (Optional) Use OIDC to authenticate to Azure
           # arm_client_secret: ${{ secrets.ARM_CLIENT_SECRET }} ## (Required - Dependabot Secrets) ARM Client Secret
           arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }} ## (Required - Dependabot Secrets) ARM Subscription ID
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }} ## (Required - Dependabot Secrets) ARM Tenant ID

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,9 @@ on:
 jobs:
   terraform-plan:
     runs-on: ubuntu-latest
+    environment: e2e-test
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       issues: write
@@ -26,7 +28,7 @@ jobs:
         uses: actions/checkout@v4.2.0
 
       - name: Run Automated Tests - Terraform Plan
-        uses: Pwd9000-ML/terraform-azurerm-tests@v1.0.6
+        uses: Pwd9000-ML/terraform-azurerm-tests@v1.1.0
         with:
           test_type: plan ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.
@@ -37,7 +39,7 @@ jobs:
           az_storage_acc: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
           az_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
           arm_client_id: ${{ secrets.ARM_CLIENT_ID }} ## (Required - Dependabot Secrets) ARM Client ID
-          arm_client_secret: ${{ secrets.ARM_CLIENT_SECRET }} ## (Required - Dependabot Secrets) ARM Client Secret
+          # arm_client_secret: ${{ secrets.ARM_CLIENT_SECRET }} ## (Required - Dependabot Secrets) ARM Client Secret
           arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }} ## (Required - Dependabot Secrets) ARM Subscription ID
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }} ## (Required - Dependabot Secrets) ARM Tenant ID
           github_token: ${{ secrets.GITHUB_TOKEN }} ## (Required) Needed to comment output on PR's. ${{ secrets.GITHUB_TOKEN }} already has permissions.

--- a/.github/workflows/dependency-tests.yml
+++ b/.github/workflows/dependency-tests.yml
@@ -14,29 +14,31 @@ jobs:
   # Dependabot will open a PR on terraform version changes, this 'dependabot' job is only used to test TF version changes by running a plan, apply and destroy in sequence.
   dependabot-plan-apply-destroy:
     runs-on: ubuntu-latest
+    environment: e2e-test
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       issues: write
       actions: read
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # Remember to change the condition on dependabot job after testing.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.0
 
       - name: Run Dependency Tests - Plan AND Apply AND Destroy
-        uses: Pwd9000-ML/terraform-azurerm-tests@v1.0.6
+        uses: haflidif/terraform-azure-tests@main
         with:
           test_type: plan-apply-destroy ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.
           tf_version: latest ## (Optional) Specifies version of Terraform to use. e.g: 1.1.0 Default="latest"
-          tf_vars_file: testing.tfvars ## (Required) Specifies Terraform TFVARS file name inside module path (Testing vars)
-          tf_key: tf-mod-test-alz-subnet ## (Required) AZ backend - Specifies name that will be given to terraform state file and plan artifact (testing state)
+          tf_var_file: testing.tfvars ## (Required) Specifies Terraform TFVARS file name inside module path (Testing vars)
+          tf_state_file: tf-mod-test-alz-subnet ## (Required) AZ backend - Specifies name that will be given to terraform state file and plan artifact (testing state)
           az_resource_group: rg-azviking-tfstate ## (Required) AZ backend - AZURE Resource Group hosting terraform backend storage account
-          az_storage_acc: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
-          az_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
+          az_storage_account_name: stazvikingstatec2e559ef ## (Required) AZ backend - AZURE terraform backend storage account
+          az_storage_container_name: test ## (Required) AZ backend - AZURE storage container hosting state files
           arm_client_id: ${{ secrets.ARM_CLIENT_ID }} ## (Required - Dependabot Secrets) ARM Client ID
-          arm_client_secret: ${{ secrets.ARM_CLIENT_SECRET }} ## (Required - Dependabot Secrets) ARM Client Secret
           arm_subscription_id: ${{ secrets.ARM_SUBSCRIPTION_ID }} ## (Required - Dependabot Secrets) ARM Subscription ID
           arm_tenant_id: ${{ secrets.ARM_TENANT_ID }} ## (Required - Dependabot Secrets) ARM Tenant ID
           github_token: ${{ secrets.GITHUB_TOKEN }} ## (Required) Needed to comment output on PR's. ${{ secrets.GITHUB_TOKEN }} already has permissions.


### PR DESCRIPTION
This PR updates the dependency tests and automated PR tests to utilize the new `haflidif/terraform-azure-tests` GitHub Action. The new action introduces the capability to use User Assigned Managed Identity and Federated Credentials instead of the old method of using Client Secrets with a Service Principal.

These changes enhance the security and flexibility of our CI/CD pipeline by leveraging managed identities and federated credentials.