### PR TITLE
Refactor E2E Test Action

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,6 +11,12 @@ on:
       - 'test/autotest/**'
       - '*/**.tf'
       - '!examples/**'
+  
+  push:
+    paths:
+      - 'test/autotest/**'
+      - '*/**.tf'
+      - '!examples/**'
 
   workflow_dispatch:
 
@@ -25,7 +31,7 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name != 'pull_request' || github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -48,8 +54,7 @@ jobs:
           arm_use_azuread: true
 
   terraform-apply:
-    needs: terraform-plan
-    name: "Automated Apply"
+    name: "Automated E2E Test"
     runs-on: ubuntu-latest
     environment: e2e-test-apply
     permissions:
@@ -58,7 +63,7 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -66,7 +71,7 @@ jobs:
       - name: E2E Test - Terraform Plan and Apply
         uses: haflidif/terraform-azure-tests@v1.1.0
         with:
-          test_type: plan-apply ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
+          test_type: plan-apply-destroy ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.
           tf_version: latest ## (Optional) Specifies version of Terraform to use. e.g: 1.1.0 Default="latest"
           tf_var_file: testing.tfvars ## (Required) Specifies Terraform TFVARS file name inside module path (Testing vars)

--- a/test/autotest/main.tf
+++ b/test/autotest/main.tf
@@ -240,3 +240,5 @@ output "network_security_group_ids" {
     subnet_existing_rg_no_rt   = module.subnet_existing_rg_no_rt.subnet_nsg_id
   }
 }
+
+# Testing Trigger


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/e2e-test.yml` file to improve the workflow for end-to-end testing, and a minor comment addition to the `test/autotest/main.tf` file. The most important changes include adding a push trigger, modifying job conditions, renaming a job, and changing the test type for the Terraform plan and apply step.

Changes to `.github/workflows/e2e-test.yml`:

* Added a `push` trigger to the workflow with specific paths to monitor for changes.
* Modified the condition for running jobs to include checks for the event name and actor. [[1]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L28-R34) [[2]](diffhunk://#diff-5cc2c864012004f60ee3f9078fa1c4a8721c6b841e386c57f12bea58b692e6e2L61-R74)
* Renamed the `terraform-apply` job to `Automated E2E Test`.
* Changed the `test_type` parameter in the Terraform step from `plan-apply` to `plan-apply-destroy`.

Changes to `test/autotest/main.tf`:

* Added a comment for testing triggers.