### PR TITLE
Update Terraform action versions in e2e-test workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: E2E Test - Terraform Plan
-        uses: haflidif/terraform-azure-plan@testing-new-pr-commenter
+        uses: haflidif/terraform-azure-plan@v1.2.0
         with:
           path: "test/autotest" ## (Optional) Specify path to test module to run.
           tf_version: latest ## (Optional) Specifies version of Terraform to use. e.g: 1.1.0 Default="latest"
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       
       - name: E2E Test - Terraform Plan and Apply
-        uses: haflidif/terraform-azure-tests@v1.1.0
+        uses: haflidif/terraform-azure-tests@v1.2.0
         with:
           test_type: plan-apply-destroy ## (Required) Valid options are "plan", "plan-apply", "plan-apply-destroy". Default="plan"
           path: "test/autotest" ## (Optional) Specify path to test module to run.


### PR DESCRIPTION
This pull request updates the versions of the Terraform action used in the end-to-end test workflow. The most important changes are as follows:

Version updates in `.github/workflows/e2e-test.yml`:

* Updated `haflidif/terraform-azure-plan` action to version `v1.2.0` for the E2E Test - Terraform Plan job.
* Updated `haflidif/terraform-azure-tests` action to version `v1.2.0` for the E2E Test - Terraform Plan and Apply job.