### PR TITLE
docs: updating documentation to reflect recent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Please have a look at the [Known Issues](#known-issues) section for more informa
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.9, < 2.2 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.11, < 4.15 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.9, < 2.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.11, < 4.28 |
 
   ## Simple module usage
       


### PR DESCRIPTION
This pull request updates the version constraints for two Terraform providers in the `README.md` file to reflect compatibility with newer versions.

Version constraint updates:

* Updated the `azapi` provider version constraint to allow versions up to `< 2.4` (previously `< 2.2`). (`README.md`, [README.mdL36-R37](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R37))
* Updated the `azurerm` provider version constraint to allow versions up to `< 4.28` (previously `< 4.15`). (`README.md`, [README.mdL36-R37](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R37))